### PR TITLE
Fix haproxy restart.

### DIFF
--- a/haproxy.ctmpl
+++ b/haproxy.ctmpl
@@ -1,5 +1,5 @@
 global
-    maxconn 256
+    maxconn 2000 
     pidfile /var/run/haproxy-private.pid
 
 defaults

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash 
+
 if [ -n "$STATSD_HOST" ]; then
     HAPROXY_HOST="http://127.0.0.1:1936/;csv" HAPROXY_USER=stats HAPROXY_PASS=stats /bin/haproxy-statsd.py &
 fi
 
 consul-template \
     -consul $CONSUL_SERVER \
-    -template "/tmp/haproxy.ctmpl:/usr/local/etc/haproxy/haproxy.cfg:haproxy -f /usr/local/etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf \$(cat /var/run/haproxy.pid) &"
+    -template "/tmp/haproxy.ctmpl:/usr/local/etc/haproxy/haproxy.cfg:haproxy -D -f /usr/local/etc/haproxy/haproxy.cfg -p /var/run/haproxy-private.pid -sf \$(cat /var/run/haproxy-private.pid) &"


### PR DESCRIPTION
- Add option -D to consul template command so that we can actually reload haproxy
- Increase max number of connection in haproxy
- Consistently reference haproxy PID file.
